### PR TITLE
Add optional output directory argument to generators

### DIFF
--- a/tests/generate-class-with-default-values.cpp
+++ b/tests/generate-class-with-default-values.cpp
@@ -2,7 +2,11 @@
 #include <iostream>
 #include <fstream>
 
-int main(){
+#include "generator_util.h"
+
+int main( int argc, char** argv ){
+    optional_chdir( argc, argv );
+
     cppgenerate::Class c( "ClassWithDefaultValues" );
 
     c.addConstructor( cppgenerate::Constructor::create()

--- a/tests/generate-class-with-method.cpp
+++ b/tests/generate-class-with-method.cpp
@@ -2,7 +2,11 @@
 #include <iostream>
 #include <fstream>
 
-int main(){
+#include "generator_util.h"
+
+int main( int argc, char** argv ){
+    optional_chdir( argc, argv );
+
     cppgenerate::Class c( "ClassWithMethod" );
 
     c.addMethod( cppgenerate::Method::create()

--- a/tests/generate-class1.cpp
+++ b/tests/generate-class1.cpp
@@ -2,7 +2,11 @@
 #include <iostream>
 #include <fstream>
 
+#include "generator_util.h"
+
 int main( int argc, char** argv ){
+    optional_chdir( argc, argv );
+
     cppgenerate::Class c( "FooClass" );
 
     c.setNamespace( "Bar" )

--- a/tests/generate-imperative-math.cpp
+++ b/tests/generate-imperative-math.cpp
@@ -2,7 +2,11 @@
 #include <iostream>
 #include <fstream>
 
-int main(){
+#include "generator_util.h"
+
+int main( int argc, char** argv ){
+    optional_chdir( argc, argv );
+
     /* Create a class called MathOperations */
     cppgenerate::Class c( "MathOperations" );
 

--- a/tests/generate-namespace-class.cpp
+++ b/tests/generate-namespace-class.cpp
@@ -2,7 +2,11 @@
 #include <iostream>
 #include <fstream>
 
-int main(){
+#include "generator_util.h"
+
+int main( int argc, char** argv ){
+    optional_chdir( argc, argv );
+
     cppgenerate::Class c( "NamespaceClass" );
 
     c.setNamespace( "Bar" );

--- a/tests/generator_util.h
+++ b/tests/generator_util.h
@@ -1,0 +1,85 @@
+#include <iostream>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <fcntl.h>
+#include <io.h>
+#else
+#include <unistd.h>
+#include <string.h>
+#endif
+
+#if defined(_WIN32)
+struct WinError{
+    DWORD last_error;
+
+    WinError( DWORD error ) : last_error( error ) {}
+
+    friend std::wostream& operator<<( std::wostream& os, const WinError& what ){
+        LPWSTR error_msg = nullptr;
+
+        size_t size = FormatMessageW(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                FORMAT_MESSAGE_IGNORE_INSERTS,
+            nullptr, what.last_error, MAKELANGID( LANG_NEUTRAL, SUBLANG_DEFAULT ),
+            (LPWSTR)&error_msg, 0, nullptr);
+
+        if ( size == 0 )
+            os << L"error code " << what.last_error;
+        else{
+            os << error_msg;
+            LocalFree( error_msg );
+        }
+
+        return os;
+    }
+};
+#endif
+
+/* chdir into the path specified in the first argument if there is any specified. */
+inline void optional_chdir( int argc, char** argv ){
+#if defined(_WIN32)
+    _setmode(_fileno(stderr), _O_U16TEXT);
+
+    int win_argc;
+    LPWSTR* win_argv = CommandLineToArgvW( GetCommandLineW(), &win_argc );
+
+    if ( win_argv == nullptr ){
+        std::wcerr << L"Couldn't retrieve commandline arguments: "
+            << WinError( GetLastError() ) << L'\n';
+        std::exit( 1 );
+    }
+
+    if ( win_argc > 2 ){
+        std::wcerr << L"Superfluous command-line arguments specified!\n";
+        std::exit( 1 );
+    }
+
+    if ( win_argc == 2 ){
+        if (!SetCurrentDirectoryW(win_argv[1])){
+            std::wcerr << L"Couldn't chdir into '" << win_argv[1]
+                << L"': " << WinError( GetLastError() ) << L'\n';
+            std::exit( 1 );
+        }
+    }
+
+    if ( LocalFree(win_argv) != nullptr ){
+        std::wcerr << L"Couldn't free argument list: "
+            << WinError( GetLastError() ) << L'\n';
+        std::exit( 1 );
+    }
+#else
+    if ( argc > 2 ){
+        std::cerr << "Superfluous command-line arguments specified!\n";
+        std::exit( 1 );
+    }
+
+    if ( argc == 2 ){
+        if ( chdir( argv[1] ) < 0 ){
+            std::cerr << "Couldn't chdir into '" << argv[1] << "': "
+                << strerror( errno ) << '\n';
+            std::exit( 1 );
+        }
+    }
+#endif
+}


### PR DESCRIPTION
I have discussed this change in #5.

Utilities which create files determine their location by either having the user explicitly specify the filenames (using command-line arguments for example) or by at least specifying the output directory to which the files should be saved.

Current test generators always put hardcoded filenames into the current working directory. This is inflexible. This behavior is understandable, because test programs shouldn't be held to the same standard as user-facing CLI utilities, however, this issue happens to negatively affect Meson integration.

This isn't a bug fix, the old behavior is fully functional.

I have done extensive testing of this system on Windows. I can confirm that localisation of error messages and filesystem paths containing unicode characters work as expected.

I have also verified that this change fixes the issues I've had with Meson integration (briefly touched upon at #5).